### PR TITLE
Render fields' enumerated values when present

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.53"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "atty"
@@ -42,16 +42,16 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "clap"
-version = "3.0.7"
+version = "3.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e8611f9ae4e068fa3e56931fded356ff745e70987ff76924a6e0ab1c8ef2e3"
+checksum = "d646c7ade5eb07c4aa20e907a922750df0c448892513714fd3e4acbc7130829f"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
- "lazy_static",
- "os_str_bytes",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
@@ -59,15 +59,24 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.6"
+version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -120,29 +129,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
-name = "minijinja"
-version = "0.13.0"
+name = "memo-map"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30f17c534db2eedae437efc317ff3b9a8921dff9bdaa9003b61c8187515e2d4"
+checksum = "aec276c09560ce4447087aaefc19eb0c18d97e31bd05ebac38881c4723400c40"
+
+[[package]]
+name = "minijinja"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccff60140963c1feb2858b2e3250187397a8aaaba14b36841ec00889039a97c3"
 dependencies = [
+ "memo-map",
  "self_cell",
  "serde",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "proc-macro-error"
@@ -241,9 +254,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "svd-parser"
-version = "0.13.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab467c4fa2025fa0c4131337bd05106f05df9a663f97ab9db0e4a3a3f2b862e8"
+checksum = "e41489e88698a6430a19dff2790eb8450e4fb8a3a874b5cb749d0fbacbcc3992"
 dependencies = [
  "anyhow",
  "roxmltree",
@@ -253,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "svd-rs"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09dd36c191151d2531dab34f2769fed21c2ba355f7b781b223d42259f17b856"
+checksum = "0dff9fc46f6c0a243e3356d25cd481d5d34e4e8d4049f53f72eda349c35ade14"
 dependencies = [
  "once_cell",
  "regex",
@@ -295,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow      = "1.0.53"
-clap        = { version = "3.0.7",  features = ["derive"] }
+anyhow      = "1.0.58"
+clap        = { version = "3.2.11",  features = ["derive"] }
 lazy_static = "1.4.0"
-minijinja   = { version = "0.13.0", features = ["source"] }
-svd-parser  = "0.13.1"
+minijinja   = { version = "0.17.0", features = ["source"] }
+svd-parser  = "0.13.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,12 +171,13 @@ fn fields(register: &MaybeArray<RegisterInfo>) -> Vec<Value> {
     fields_with_spans(register)
         .iter()
         .map(|(f, from, to)| {
-            let (name, desc, access) = field_info(f);
+            let (name, desc, access, values) = field_info(f);
 
             context! {
                 name        => name,
                 description => desc,
                 access      => access,
+                values      => values,
 
                 span => from - to + 1,
                 text => if from == to {
@@ -226,10 +227,11 @@ fn fields_with_spans(
     fields
 }
 
-fn field_info(field: &Option<&MaybeArray<FieldInfo>>) -> (String, String, String) {
+fn field_info(field: &Option<&MaybeArray<FieldInfo>>) -> (String, String, String, Vec<String>) {
     let mut name = String::new();
     let mut desc = String::new();
     let mut access = String::from("-");
+    let mut values = Vec::new();
 
     if let Some(f) = field {
         name = f.name.clone();
@@ -249,9 +251,15 @@ fn field_info(field: &Option<&MaybeArray<FieldInfo>>) -> (String, String, String
             None => "-",
         }
         .to_string();
+
+        for ev in f.enumerated_values.iter() {
+            for v in ev.values.iter() {
+                values.push(format!("{:02b}: {}", v.value.unwrap(), v.name));
+            }
+        }
     }
 
-    (name, desc, access)
+    (name, desc, access, values)
 }
 
 fn write_html(source: &str, path: &Path) -> Result<()> {

--- a/templates/peripheral.html
+++ b/templates/peripheral.html
@@ -86,6 +86,7 @@
         <th>Field</th>
         <th>Access</th>
         <th colspan="3">Description</th>
+        <th>Enumerated Values</th>
       </tr>
     </thead>
     <tbody>
@@ -94,6 +95,13 @@
         <td><strong>{{ field.name }}</strong></td>
         <td>{{ field.access }}</td>
         <td colspan="3">{{ field.description }}</td>
+        <td>
+          <ul>
+          {% for value in field.values %}
+            <li>{{ value }}</li>
+          {% endfor %}
+          </ul>
+        </td>
       </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
There aren't many of these in our SVDs yet, but there will be eventually. There are some for the ESP32, so I was able to verify using these. You can check out `RTC_CNTL` -> `CLK_CONF` to see this:

<img width="960" alt="Screen Shot 2022-07-13 at 11 56 46" src="https://user-images.githubusercontent.com/1945813/178811075-f9c3b9a2-5d3e-46db-ad51-f870aa06ad88.png">

I also bumped all the dependencies, because why not.